### PR TITLE
sample playbook was failing on controller 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To use this role you can create a playbook such as the following:
       api_key: "{{ctrl_globals.json.currentStatus.agentSettings.apiKey}}"
       nginx_controller_fqdn: "{{ nginx_controller_fqdn }}"
 
-- hosts: wafs
+- hosts: tag_new_gateway
   remote_user: ubuntu
   become: true
   become_method: sudo
@@ -81,6 +81,7 @@ To use this role you can create a playbook such as the following:
       packages:
       - python-minimal
       - libxerces-c3.2
+      
   - name: install the agent
     include_role:
       name: nginxinc.nginx_controller.nginx_controller_agent

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To use this role you can create a playbook such as the following:
       packages:
       - python-minimal
       - libxerces-c3.2
-      
+
   - name: install the agent
     include_role:
       name: nginxinc.nginx_controller.nginx_controller_agent

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ To use this role you can create a playbook such as the following:
   - name: Copy api_key to a variable
     set_fact:
       api_key: "{{ctrl_globals.json.currentStatus.agentSettings.apiKey}}"
+      nginx_controller_fqdn: "{{ nginx_controller_fqdn }}"
 
-- hosts: tag_new_gateway
+- hosts: wafs
   remote_user: ubuntu
   become: true
   become_method: sudo
@@ -80,12 +81,12 @@ To use this role you can create a playbook such as the following:
       packages:
       - python-minimal
       - libxerces-c3.2
-
   - name: install the agent
     include_role:
       name: nginxinc.nginx_controller.nginx_controller_agent
     vars:
       nginx_controller_api_key: "{{ hostvars['localhost']['api_key'] }}"
+      nginx_controller_fqdn: "{{ hostvars['localhost']['nginx_controller_fqdn'] }}"
 ```
 
 You can then run `ansible-playbook nginx_controller_agent.yaml` to execute the playbook.


### PR DESCRIPTION
Feel free to discard this request - just thought it was the easiest method to report the issue I had.

error was:
fatal: [ubuntu-nap5]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: {{ hostvars['localhost']['nginx_controller_fqdn'] }}: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'nginx_controller_fqdn'\n\nThe error appears to be in '/home/ubuntu/.ansible/collections/ansible_collections/nginxinc/nginx_controller/roles/nginx_controller_agent/tasks/main.yml': line 15, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Download the installer script from NGINX Controller\n  ^ here\n"}